### PR TITLE
add missing affiliation cross-reference

### DIFF
--- a/_episodes/10-authorship.md
+++ b/_episodes/10-authorship.md
@@ -63,7 +63,10 @@ Moving back to the RO-Crate root `./`, let's specify who are the authors of the 
 > > {
 > >   "@id": "https://orcid.org/0000-0002-1825-0097",
 > >   "@type": "Person", 
-> >   "name": "Josiah Carberry"
+> >   "name": "Josiah Carberry",
+> >   "affiliation": {
+> >     "@id": "https://ror.org/05gq02987"
+> >   }
 > > },
 > > {
 > >   "@id": "https://ror.org/05gq02987",


### PR DESCRIPTION
Hello,
I think I spotted a missing bit from the page 10-authorship. 

When the affiliation of the author is replaced from plain text to cross-referencing a ROR, the cross-reference is missing from the author's attributes.

Thanks for the very instructive tutorial

Cheers,
Tom
